### PR TITLE
fix: 同页面多个v-editor的height, disabled属性冲突

### DIFF
--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -94,9 +94,9 @@ export default {
   },
   watch: {
     disabled(val, oldVal) {
-      document.querySelector('.w-e-toolbar').style['pointer-events'] = val
-        ? 'none'
-        : ''
+      this.$refs.editor.querySelector('.w-e-toolbar').style[
+        'pointer-events'
+      ] = val ? 'none' : ''
       this.editor.$textElem.attr('contenteditable', !val)
     },
     value(val, oldVal) {
@@ -145,14 +145,13 @@ export default {
     //设置默认值
     editor.txt.html(editorValue(this.value))
     //是否禁用编辑器
-    document.querySelector('.w-e-toolbar').style['pointer-events'] = this
-      .disabled
-      ? 'none'
-      : ''
+    this.$refs.editor.querySelector('.w-e-toolbar').style[
+      'pointer-events'
+    ] = this.disabled ? 'none' : ''
     editor.$textElem.attr('contenteditable', !this.disabled)
 
     //设置编辑器的高度
-    document.querySelector('.w-e-text-container').style.height = `${
+    this.$refs.editor.querySelector('.w-e-text-container').style.height = `${
       this.height
     }px`
 


### PR DESCRIPTION
## Why
1. #14 ，同页面多个v-editor的height, disabled属性冲突
2. 组件内选取menu和text-editor使用`document.querySelector`函数，意味着单页面多个编辑器的height和disabled属性都设置在首个v-editor上

## How
将`document.querySelector`替换为`this.$refs.editor.querySelector`
