### PR TITLE
fix: 粘贴外链图片显示了两张同样的图片

### DIFF
--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -235,7 +235,10 @@ export default {
       this.$emit('upload-loading', false)
     },
     paste(e) {
-      if (!e.clipboardData.files.length) return
+      const {clipboardData} = e
+      const {files, types} = clipboardData
+      const isCopyFromWeb = types.some(type => type === 'text/html')
+      if (!files.length || isCopyFromWeb) return
       this.$refs.uploadToAli.paste(e)
     }
   }


### PR DESCRIPTION
## Why
fix #41

## How
Describe your steps:
1. 判断 clipboardData 的 types 数组是否存在 `text/html`
2. 若存在则不调用 upload-to-ali 的上传
3. 反之则调用 upload-to-ali 的上传

Ps: 暂时只支持粘贴单张网络图片

## Test
- [x] 截图直接粘贴
![截图直接粘贴](https://user-images.githubusercontent.com/27187946/64933779-3a2a3d80-d879-11e9-95e6-f9df18622345.gif)

- [x] 复制本地图片粘贴
![复制本地图片粘贴](https://user-images.githubusercontent.com/27187946/64934646-bf642100-d87e-11e9-94a4-e1805ce48e1e.gif)

- [x] 复制网络图片粘贴
![复制浏览器图片粘贴](https://user-images.githubusercontent.com/27187946/64934654-d0ad2d80-d87e-11e9-8fef-679632807475.gif)

