### PR TITLE
fix: 在图片前按`回车`会清空内容

### DIFF
--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -82,7 +82,6 @@ export default {
   },
   data() {
     return {
-      enableUpdateValue: true,
       showLoading: false
     }
   },

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -25,7 +25,7 @@ import E from 'wangeditor'
 import UploadToAli from '@femessage/upload-to-ali'
 import defaultEditorOptions from './defaultEditorOptions'
 
-const HTML_PATTERN = /^<[a-z].*>$/i
+const HTML_PATTERN = /^<[a-z\s]+class="text-box"/i
 
 // 对齐wangEditor的样式
 const editorValue = val =>
@@ -126,16 +126,7 @@ export default {
      * 2. 空内容的quote块
      * 3. 空内容的table
      */
-    editor.customConfig.onchange = html => {
-      // 不使用editor.txt.text()的原因是，该方法返回的是去掉标签的html内容，则空格是&nbsp，无法被trim
-      const noText = !editor.$textElem[0].textContent
-        .trim()
-        // 处理斜体和加粗符号('zero-width space')
-        .replace(/\u200b/g, '')
-
-      const noImg = !html.includes('img')
-      this.$emit('input', noText && noImg ? '' : html)
-    }
+    editor.customConfig.onchange = this.emitValue
 
     editor.customConfig.onfocus = html => {
       // 选中焦点时不处理watch value
@@ -148,8 +139,6 @@ export default {
 
     editor.create()
 
-    //设置默认值
-    editor.txt.html(editorValue(this.value))
     //是否禁用编辑器
     editor.$textElem.attr('contenteditable', !this.disabled)
 
@@ -189,6 +178,10 @@ export default {
 
     //保存实例，用于后续处理
     this.editor = editor
+
+    //设置默认值
+    editor.txt.html(this.value)
+    this.emitValue(this.value)
   },
   methods: {
     /**
@@ -240,6 +233,16 @@ export default {
       const isCopyFromWeb = types.some(type => type === 'text/html')
       if (!files.length || isCopyFromWeb) return
       this.$refs.uploadToAli.paste(e)
+    },
+    emitValue(html = '') {
+      // 不使用editor.txt.text()的原因是，该方法返回的是去掉标签的html内容，则空格是&nbsp，无法被trim
+      const noText = !this.editor.$textElem[0].textContent
+        .trim()
+        // 处理斜体和加粗符号('zero-width space')
+        .replace(/\u200b/g, '')
+
+      const noImg = !html.includes('img')
+      this.$emit('input', noText && noImg ? '' : editorValue(html))
     }
   }
 }

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -111,14 +111,7 @@ export default {
     editor.customConfig.onchangeTimeout =
       this.editorOptions.onchangeTimeout || defaultEditorOptions.onchangeTimeout // 单位 ms
 
-    /**
-     * onchange里要处理空值校验的问题:
-     * 目标：v-editor视觉上内容为空(无文本无图片)时，value为''
-     * 默认情况下，v-editor视觉上内容为空时，value不为空，可能包括以下情况：
-     * 1. 空内容的斜体、加粗符号
-     * 2. 空内容的quote块
-     * 3. 空内容的table
-     */
+    // 详细注释以及解释可以参考 emitValue 行号大约为 225
     editor.customConfig.onchange = this.emitValue
 
     editor.create()
@@ -218,8 +211,23 @@ export default {
       if (!files.length || isCopyFromWeb) return
       this.$refs.uploadToAli.paste(e)
     },
+
+    /**
+     * emitValue 里要处理空值校验的问题:
+     * 目标： v-editor 视觉上内容为空(无文本无图片)时，向上输出的 value 为 ''
+     * 默认情况下，v-editor 视觉上内容为空时，value 不为空，可能包括以下情况：
+     * 1. 空内容的斜体、加粗符号
+     * 2. 空内容的 quote 块
+     * 3. 空内容的 table
+     *      table是通过menu插入的表格。
+     *      wangEditor源码里默认生成的table每一个格子里都有一个空格&nbsp
+     */
     emitValue(html = '') {
-      // 不使用editor.txt.text()的原因是，该方法返回的是去掉标签的html内容，则空格是&nbsp，无法被trim
+      /**
+       * 不使用 editor.txt.text() 的原因是
+       * 该方法返回的是去掉标签的html内容
+       * 但空格是&nbsp，无法被trim
+       */
       const noText = !this.editor.$textElem[0].textContent
         .trim()
         // 处理斜体和加粗符号('zero-width space')

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -92,12 +92,6 @@ export default {
         'pointer-events'
       ] = val ? 'none' : ''
       this.editor.$textElem.attr('contenteditable', !val)
-    },
-    value(val, oldVal) {
-      //更新编辑器内容会导致光标偏移, 故只在blur之后更新
-      if (this.enableUpdateValue) {
-        this.editor && this.editor.$textElem.html(editorValue(val))
-      }
     }
   },
   mounted() {
@@ -127,15 +121,6 @@ export default {
      * 3. 空内容的table
      */
     editor.customConfig.onchange = this.emitValue
-
-    editor.customConfig.onfocus = html => {
-      // 选中焦点时不处理watch value
-      this.enableUpdateValue = false
-    }
-    editor.customConfig.onblur = html => {
-      // 失去焦点时watch value
-      this.enableUpdateValue = true
-    }
 
     editor.create()
 


### PR DESCRIPTION
close #44 

## Why

- 存在用户反馈, 先插入图片在倒退回去插入内容, 会造成内容消失, 体验极度不友好.

### 猜测起因

在 `editor.txt.html(editorValue(this.value))` 的 `editorValue` 包装的 `div` 导致

步骤如下:

上传了图片, 控制台打印信息显示正确

![image](https://user-images.githubusercontent.com/53422750/65037627-af346a80-d980-11e9-82bb-99ff65c1620d.png)

在图片前面按了回车后, 内部 onchange 判断 `noText` 和 `noImg` 条件成立, 提交了个 `''` .

![image](https://user-images.githubusercontent.com/53422750/65028774-2cef7a80-d96f-11e9-9308-f49d80d488cd.png)

## How

1. 赋值给 editor 的内容不需要使用 `editorValue` 包装.

```diff
L 152

- editor.txt.html(editorValue(this.value))
+ editor.txt.html(this.value)
```

2. 调整赋值

3. 修改 `editorValue` 包装器函数

> 理由: 如果储存的数据来自 `V Editor`, 则初始化的赋值不需要重新包装一个 `div` .

```diff
- const HTML_PATTERN = /^<[a-z].*>$/i
+ const HTML_PATTERN = /^<[a-z\s]+class="text-box"/i
```

## Test

### 修改前

![enter_before](https://user-images.githubusercontent.com/53422750/65037656-bd828680-d980-11e9-89b8-5dc0b5475188.gif)

### 修改后

![enter_after](https://user-images.githubusercontent.com/53422750/65037674-c7a48500-d980-11e9-840a-d97dbd989d74.gif)

### 另外的小修复

猜测原由: 由于 `editorValue` 的初始值为 `div>br`, 导致 editor 实际上有空行才可以删减, 但由于 emit.input 有过滤, 所以对实际输出的值没影响.

> gif 无法体现, 变化太快, 帧率跟不上.

步骤如下:

1. 进入编辑器并且聚焦
2. 什么也不输入直接敲下 ← backspace
3. 会发现光标瞬间向上跳动