### PR TITLE
fix(hack): 解决光标聚焦问题

### DIFF
--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -19,7 +19,7 @@ export default {
   },
 
   methods: {
-    initTextElementFocusEvent() {
+    initTextElementEvent() {
       // 初始使之失焦以使得编辑框 `聚焦` 或 `失焦` 时得到理想效果
       this.editor.$textElem[0].blur()
 

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -3,12 +3,12 @@
  * `editor.$textElem[0]` 指的是实际可编辑的输入框
  */
 
-const menuItemsStore = []
+const menuItems = []
 
 export default {
   beforeDestory() {
-    if (menuItemsStore.length) {
-      menuItemsStore.forEach(item => {
+    if (menuItems.length) {
+      menuItems.forEach(item => {
         item.removeEventListener('click', this.handleMenuItemClick)
       })
     }
@@ -46,7 +46,7 @@ export default {
 
     addToolbarItemClickEvent(item) {
       item.addEventListener('click', this.handleMenuItemClick)
-      menuItemsStore.push(item)
+      menuItems.push(item)
     },
 
     handleTextElementBlur() {

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -45,11 +45,11 @@ export default {
     },
 
     handleTextElementBlur() {
-      this.enableUpdateValue = false
+      this.enableUpdateValue = true
     },
 
     handleTextElementFocus() {
-      this.enableUpdateValue = true
+      this.enableUpdateValue = false
     }
   }
 }

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -3,13 +3,13 @@
  * `editor.$textElem[0]` 指的是实际可编辑的输入框
  */
 
-const menuItems = []
+const toolbarItems = []
 
 export default {
   beforeDestory() {
     // 清除每个 menuItem 的点击事件监听器
-    if (menuItems.length) {
-      menuItems.forEach(item => {
+    if (toolbarItems.length) {
+      toolbarItems.forEach(item => {
         item.removeEventListener('click', this.handleMenuItemClick)
       })
     }
@@ -47,7 +47,7 @@ export default {
 
     addToolbarItemClickEvent(item) {
       item.addEventListener('click', this.handleMenuItemClick)
-      menuItems.push(item)
+      toolbarItems.push(item)
     },
 
     handleTextElementBlur() {

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -25,7 +25,7 @@ export default {
   },
 
   methods: {
-    initTextElementEvent() {
+    initFocusHack() {
       // 初始使之失焦以使得编辑框 `聚焦` 或 `失焦` 时得到理想效果
       this.editor.$textElem[0].blur()
 

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -40,14 +40,14 @@ export default {
       )
     },
 
+    initToolbarItemFocusHack(item) {
+      item.addEventListener('click', this.handleMenuItemClick)
+      toolbarItems.push(item)
+    },
+
     handleMenuItemClick() {
       this.editor.$textElem[0].focus()
       this.enableUpdateValue = false
-    },
-
-    addToolbarItemClickEvent(item) {
-      item.addEventListener('click', this.handleMenuItemClick)
-      toolbarItems.push(item)
     },
 
     handleTextElementBlur() {

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -7,6 +7,7 @@ const menuItems = []
 
 export default {
   beforeDestory() {
+    // 清除每个 menuItem 的点击事件监听器
     if (menuItems.length) {
       menuItems.forEach(item => {
         item.removeEventListener('click', this.handleMenuItemClick)

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -1,3 +1,8 @@
+/**
+ * 一些小说明:
+ * `editor.$textElem[0]` 指的是实际可编辑的输入框
+ */
+
 const menuItemsStore = []
 
 export default {

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -1,0 +1,57 @@
+const menuItemsStore = []
+
+export default {
+  mounted() {
+    this.$nextTick(() => {
+      // 初始使之失焦以使得编辑框 `聚焦` 或 `失焦` 时得到理想效果
+      this.editor.$textElem[0].blur()
+
+      this.editor.$textElem[0].addEventListener(
+        'focus',
+        this.handleTextElementFocus
+      )
+
+      this.editor.$textElem[0].addEventListener(
+        'blur',
+        this.handleTextElementBlur
+      )
+    })
+  },
+
+  beforeDestory() {
+    if (menuItemsStore.length) {
+      menuItemsStore.forEach(item => {
+        item.removeEventListener('click', this.handleMenuItemClick)
+      })
+    }
+
+    this.editor.$textElem[0].removeEventListener(
+      'focus',
+      this.handleTextElementFocus
+    )
+    this.editor.$textElem[0].removeEventListener(
+      'blur',
+      this.handleTextElementBlur
+    )
+  },
+
+  methods: {
+    handleMenuItemClick() {
+      this.editor.$textElem[0].focus()
+      this.enableUpdateValue = false
+    },
+
+    addToolbarItemClickEvent(item) {
+      item.addEventListener('click', this.handleMenuItemClick)
+      menuItemsStore.push(item)
+    },
+
+    handleTextElementBlur() {
+      this.enableUpdateValue = false
+    },
+
+    handleTextElementFocus() {
+      this.enableUpdateValue = true
+    }
+  }
+}

--- a/src/mixins/focusHack.js
+++ b/src/mixins/focusHack.js
@@ -1,23 +1,6 @@
 const menuItemsStore = []
 
 export default {
-  mounted() {
-    this.$nextTick(() => {
-      // 初始使之失焦以使得编辑框 `聚焦` 或 `失焦` 时得到理想效果
-      this.editor.$textElem[0].blur()
-
-      this.editor.$textElem[0].addEventListener(
-        'focus',
-        this.handleTextElementFocus
-      )
-
-      this.editor.$textElem[0].addEventListener(
-        'blur',
-        this.handleTextElementBlur
-      )
-    })
-  },
-
   beforeDestory() {
     if (menuItemsStore.length) {
       menuItemsStore.forEach(item => {
@@ -36,6 +19,21 @@ export default {
   },
 
   methods: {
+    initTextElementFocusEvent() {
+      // 初始使之失焦以使得编辑框 `聚焦` 或 `失焦` 时得到理想效果
+      this.editor.$textElem[0].blur()
+
+      this.editor.$textElem[0].addEventListener(
+        'focus',
+        this.handleTextElementFocus
+      )
+
+      this.editor.$textElem[0].addEventListener(
+        'blur',
+        this.handleTextElementBlur
+      )
+    },
+
     handleMenuItemClick() {
       this.editor.$textElem[0].focus()
       this.enableUpdateValue = false

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -117,7 +117,7 @@ export default {
     editor.customConfig.onchangeTimeout =
       this.editorOptions.onchangeTimeout || defaultEditorOptions.onchangeTimeout // 单位 ms
 
-    // 详细注释以及解释可以参考 emitValue 行号大约为 225
+    // 详细注释以及解释可以参考 emitValue 行号大约为 236
     editor.customConfig.onchange = this.emitValue
 
     // editor 聚焦时不触发 watch value

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -82,6 +82,7 @@ export default {
   },
   data() {
     return {
+      enableUpdateValue: true,
       showLoading: false
     }
   },
@@ -91,6 +92,11 @@ export default {
         'pointer-events'
       ] = val ? 'none' : ''
       this.editor.$textElem.attr('contenteditable', !val)
+    },
+    value(val) {
+      if (this.enableUpdateValue) {
+        this.editor && this.editor.txt.html(val)
+      }
     }
   },
   mounted() {
@@ -113,6 +119,11 @@ export default {
 
     // 详细注释以及解释可以参考 emitValue 行号大约为 225
     editor.customConfig.onchange = this.emitValue
+
+    // editor 聚焦时不触发 watch value
+    editor.customConfig.onfocus = () => (this.enableUpdateValue = false)
+    // editor 失焦时不触发 watch value
+    editor.customConfig.onblur = () => (this.enableUpdateValue = true)
 
     editor.create()
 

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -175,7 +175,7 @@ export default {
     editor.txt.html(this.value)
     this.emitValue(this.value)
 
-    this.initTextElementFocusEvent()
+    this.initTextElementEvent()
   },
   methods: {
     /**

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -175,7 +175,7 @@ export default {
     editor.txt.html(this.value)
     this.emitValue(this.value)
 
-    this.initTextElementEvent()
+    this.initFocusHack()
   },
   methods: {
     /**

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -153,7 +153,7 @@ export default {
       )
       item.addEventListener('mouseleave', () => (i.style.opacity = opacityIdle))
 
-      this.addToolbarItemClickEvent(item)
+      this.initToolbarItemFocusHack(item)
     })
 
     //设置编辑器的高度

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -141,12 +141,15 @@ export default {
     toolbar.style.borderColor = borderColor
     toolbar.style.borderTopLeftRadius = borderRadius
     toolbar.style.borderTopRightRadius = borderRadius
-    const opacityIdle = 0.6
-    const opacityFocus = 1
+
     toolbar.querySelectorAll('.w-e-menu').forEach(item => {
+      const opacityIdle = 0.6
+      const opacityFocus = 1
+
       const i = item.querySelector('i')
       i.style.color = '#2D303B'
       i.style.opacity = opacityIdle
+
       item.addEventListener(
         'mouseenter',
         () => (i.style.opacity = opacityFocus)

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -117,7 +117,7 @@ export default {
     editor.customConfig.onchangeTimeout =
       this.editorOptions.onchangeTimeout || defaultEditorOptions.onchangeTimeout // 单位 ms
 
-    // 详细注释以及解释可以参考 emitValue
+    // 详细注释以及解释可以参考 method: `emitValue`
     editor.customConfig.onchange = this.emitValue
 
     // editor 聚焦时不触发 watch value

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -117,7 +117,7 @@ export default {
     editor.customConfig.onchangeTimeout =
       this.editorOptions.onchangeTimeout || defaultEditorOptions.onchangeTimeout // 单位 ms
 
-    // 详细注释以及解释可以参考 emitValue 行号大约为 236
+    // 详细注释以及解释可以参考 emitValue
     editor.customConfig.onchange = this.emitValue
 
     // editor 聚焦时不触发 watch value

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -24,6 +24,7 @@
 import E from 'wangeditor'
 import UploadToAli from '@femessage/upload-to-ali'
 import defaultEditorOptions from './defaultEditorOptions'
+import mixinFocusHack from './mixins/focusHack'
 
 const HTML_PATTERN = /^<[a-z\s]+class="text-box"/i
 
@@ -33,6 +34,7 @@ const editorValue = val =>
 
 export default {
   name: 'VEditor',
+  mixins: [mixinFocusHack],
   components: {
     UploadToAli
   },
@@ -150,6 +152,8 @@ export default {
         () => (i.style.opacity = opacityFocus)
       )
       item.addEventListener('mouseleave', () => (i.style.opacity = opacityIdle))
+
+      this.addToolbarItemClickEvent(item)
     })
 
     //设置编辑器的高度
@@ -214,6 +218,7 @@ export default {
        * @property {boolean} loading - 是否加载中
        */
       this.$emit('upload-loading', false)
+      this.enableUpdateValue = false
     },
     paste(e) {
       const {clipboardData} = e

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -174,6 +174,8 @@ export default {
     //设置默认值
     editor.txt.html(this.value)
     this.emitValue(this.value)
+
+    this.initTextElementFocusEvent()
   },
   methods: {
     /**


### PR DESCRIPTION
## Fixed Bugs

- [x] **无法**异步插值
- [x] 光标从编辑框直接跳到另外的input类型(例如select)**无法**变更编辑器内容

## How

### 异步插值

1. 回退 `watch.value`
2. 回退 `editor.onfocus` 和 `editor.onblur`

### 编辑框聚/失焦

1. 为编辑框监听 focus 和 blur 事件, 使得与**手动聚/失焦编辑框**行为一致.
2. 为每个 toolbar-item 监听点击事件(使得编辑框聚焦)

以上两类监听事件在 beforeDestory 阶段会移除.