### PR TITLE
fix: 兼容自定义上传失败情况

### DIFF
--- a/docs/http-request.md
+++ b/docs/http-request.md
@@ -11,9 +11,8 @@ export default {
     return {
       content: '',
       uploadOptions: {
-        beforeUpload: () => console.log('onBefore'),
-        httpRequest: this.myUpload,
-        tip: 'refliued'
+        beforeUpload: () => console.log('before upload'),
+        httpRequest: this.myUpload
       }
     }
   },

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -226,7 +226,7 @@ export default {
       this.$emit('upload-loading', false)
       this.enableUpdateValue = false
     },
-    handleUploadFileFail(error) {
+    handleUploadFileFail() {
       this.showLoading = false
     },
     paste(e) {

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -16,6 +16,7 @@
       v-bind="uploadOptions"
       @loading="handleLoading"
       @loaded="handleUploadFileSuccess"
+      @fail="handleUploadFileFail"
     />
   </div>
 </template>
@@ -224,6 +225,9 @@ export default {
        */
       this.$emit('upload-loading', false)
       this.enableUpdateValue = false
+    },
+    handleUploadFileFail(error) {
+      this.showLoading = false
     },
     paste(e) {
       const {clipboardData} = e


### PR DESCRIPTION
## Why

- 使用自定义上传函数时, 返回 `Promise.reject` 不会关闭正在上传提示

## How

1. `<upload-to-ali>` 监听 `@fail`, 行为为 `showLoading = false`

## Test

### before

reject 后不会关闭 上传中提示

![reject1](https://user-images.githubusercontent.com/53422750/66805490-c81c4580-ef57-11e9-957b-03c6e4f3a831.gif)

### after

reject 后会关闭 上传中提示, 跟预期1秒后一致.

![reject2](https://user-images.githubusercontent.com/53422750/66805505-d10d1700-ef57-11e9-8c01-ece44292488e.gif)

### 测试代码为

https://deploy-preview-48--v-editor.netlify.com/#/Demo?id=http-request

```js
    myUpload(file) {
      return new Promise((resolve, reject) => {
        return setTimeout(() => reject('reject'), 1000)
        setTimeout(() => {
          resolve('\/\/deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg')
        }, 2000)
      })
    }
```
