### PR TITLE
fix: 修复工具栏超出宽度后未换行的问题

### DIFF
--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -273,6 +273,10 @@ export default {
     line-height: 1.5;
   }
 
+  .w-e-toolbar {
+    flex-wrap: wrap;
+  }
+
   .disabled-mask {
     position: absolute;
     background-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
## Why

编辑器工具栏超出宽度未换行

## How

flex-wrap: wrap;

## Test
### before
![image](https://user-images.githubusercontent.com/27187946/69792945-82af9100-1202-11ea-842b-4a7708cf193d.png)

### after
![image](https://user-images.githubusercontent.com/27187946/69792983-94913400-1202-11ea-8408-ac8af51ea730.png)

