### PR TITLE
docs: 更新文档用例

### DIFF
--- a/docs/editor-options.md
+++ b/docs/editor-options.md
@@ -1,5 +1,8 @@
 自定义菜单
 
+> lodash.merge 的覆盖规则是数组项合并类似 concat；
+> 目前似乎无法自定义 toolbar；要么这里改例子要么改代码
+
 ```vue
 <template>
   <v-editor v-model="content" :editor-options="editorOptions"/>
@@ -10,7 +13,17 @@ export default {
     return {
       content: '',
       editorOptions: {
-        menus: ['head', 'bold', 'image', 'table', 'code', 'undo', 'redo']
+        toolbar: [
+          'undo',
+          'redo',
+          'fullScreen',
+          '|',
+          'heading',
+          'fontSize',
+        ],
+        fontSize: {
+          options: [10, 12, 14, 'default', 18, 22, 24]
+        },
       }
     }
   },

--- a/docs/height.md
+++ b/docs/height.md
@@ -1,15 +1,14 @@
-自定义编辑区高度
+自定义编辑区高度，建议直接使用 css 来设置内部编辑区。注意是`.ck-editor__main`下紧跟的子元素`.ck-content`
 
 ```vue
 <template>
-  <v-editor v-model="content" :height="height" />
+  <v-editor class="demo" v-model="content" />
 </template>
 <script>
 export default {
   data() {
     return {
       content: '',
-      height: 800
     }
   },
   watch: {
@@ -17,6 +16,13 @@ export default {
       //打印填写内容
       console.log(val)
     }
+  },
+  created() {
+    // HACK: styleguide 示例里面用不了 style block
+    document.querySelector('style').sheet.insertRule(`
+    .demo .ck-editor__main > .ck-content {
+      height: 400px
+    }`)
   }
 }
 </script>

--- a/docs/upload-options.md
+++ b/docs/upload-options.md
@@ -12,7 +12,7 @@ export default {
       content: '',
       uploadOptions: {
         beforeUpload: () => console.log('before upload'),
-        httpRequest: this.myUpload
+        request: this.myUpload
       }
     }
   },


### PR DESCRIPTION
## Docs
### editor-options
原本是个自定义 toolbar 的示例。但目前的 merge 机制好像不支持这个用法（数组项用[合并策略](https://www.lodashjs.com/docs/latest#_mergeobject-sources)）。
暂时先更新用例并标注需要修改的点

### height
现在用 css 来定制高度

### http-request => upload-options
现在 upload-to-ali 用 request 来自定义上传
