### PR TITLE
fix: 修复图片上传问题 & link 现在新标签页打开

### DIFF
--- a/src/defaultEditorOptions.js
+++ b/src/defaultEditorOptions.js
@@ -137,5 +137,8 @@ export default {
   },
   table: {
     contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells']
+  },
+  link: {
+    addTargetToExternalLinks: true
   }
 }

--- a/src/plugin/ImageUploader.js
+++ b/src/plugin/ImageUploader.js
@@ -1,7 +1,7 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin'
 import {UploadAdapter} from '../utils/adapter'
 
-export default uploader =>
+export default uploadImg =>
   class ImageUploadAdaptor extends Plugin {
     /**
      * @inheritDoc
@@ -17,7 +17,7 @@ export default uploader =>
       const {editor} = this
       const options = editor.config.get('imageUploadOption')
       editor.plugins.get('FileRepository').createUploadAdapter = loader => {
-        return new UploadAdapter(loader, options, uploader)
+        return new UploadAdapter(loader, options, uploadImg)
       }
     }
   }

--- a/src/utils/adapter.js
+++ b/src/utils/adapter.js
@@ -1,18 +1,19 @@
 export class UploadAdapter {
-  constructor(loader, options, uploader) {
+  constructor(loader, options, uploadImg) {
     this.loader = loader
     this.options = options
-    this.uploader = uploader
+    this.uploadImg = uploadImg
   }
 
   async upload() {
     try {
+      // TODO: 检查是否多选
       const file = await this.loader.file
-      const url = await this.uploader.uploadRequest(file)
+      const url = await this.uploadImg(file)
 
-      return Promise.resolve({
+      return {
         default: url
-      })
+      }
     } catch (error) {
       console.error(error)
     }

--- a/src/utils/adapter.js
+++ b/src/utils/adapter.js
@@ -7,7 +7,7 @@ export class UploadAdapter {
 
   async upload() {
     try {
-      // TODO: 检查是否多选
+      // 图片多选时会逐个调用此方法
       const file = await this.loader.file
       const url = await this.uploadImg(file)
 

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -72,10 +72,12 @@ export default {
   },
   computed: {
     editorConfig() {
+      // $refs 在 mounted 阶段才挂载，这里不能直接传实例
+      const uploadImg = file => this.$refs.uploadToAli.uploadRequest(file)
       return merge(
         defaultEditorOptions,
         {
-          extraPlugins: [ImageUploader(this.$refs.uploadToAli)],
+          extraPlugins: [ImageUploader(uploadImg)],
           autosave: {
             save: debounce(editor => {
               /**


### PR DESCRIPTION
## Why
之前重构没有注意到 computed 不能直接访问 $refs 元素。

另外 link 现在会加上 `<a target="_blank" rel="noopener noreferer">`属性

## How
现在 upload adapter 接受一个方法

## Test
手动测试图片，附件上传 ok
![image](https://user-images.githubusercontent.com/19591950/74822030-789fb900-533f-11ea-9020-08c0c778ca24.png)
