### PR TITLE
feat: 优化列表项样式

### DIFF
--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -145,6 +145,20 @@ export default {
     }
   }
 
+  ol,
+  ul {
+    padding-left: 1em;
+  }
+
+  // 不要影响 ul 的列表项
+  ol ol {
+    list-style-type: lower-alpha;
+
+    & ol {
+      list-style-type: lower-roman;
+    }
+  }
+
   .full-screen {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Why
fix #88 
1. 列表项第二层开始用 roman，不太符合中国人认知
2. 列表项缩进太厉害

## How
1. 第二层用 alpha，往后用 roman
2. 缩进缩减 50%

## Test
![image](https://user-images.githubusercontent.com/19591950/78644499-8bb71a00-78e8-11ea-96ca-a97fb1d1a734.png)

![image](https://user-images.githubusercontent.com/19591950/78644888-34fe1000-78e9-11ea-9ce9-2d30d4fb168f.png)
