### PR TITLE
fix: default value

### DIFF
--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -60,7 +60,7 @@ export default {
      */
     value: {
       type: String,
-      default: () => ({})
+      default: ''
     },
     /**
      * editor配置


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
Why is this change required? What problem does it solve?
类型为String的默认值是'', 但现在是{}
