### PR TITLE
fix: 修复部分upload-to-ali的props不生效的问题

### DIFF
--- a/docs/upload-options.md
+++ b/docs/upload-options.md
@@ -49,7 +49,7 @@ export default {
       uploadOptions: {
         request: this.myUpload,
         size: 100,
-        onOversize: () => this.$message.warning('请选择100K以内的图片')
+        onOversize: () => console.log('请选择100K以内的图片')
       }
     }
   },

--- a/docs/upload-options.md
+++ b/docs/upload-options.md
@@ -1,5 +1,4 @@
 覆盖默认的上传行为，可以自定义上传的实现
-注意beforeUpload等上传流程外的事件可能不生效
 
 ```vue
 <template>
@@ -13,6 +12,44 @@ export default {
       content: '',
       uploadOptions: {
         request: this.myUpload
+      }
+    }
+  },
+  methods: {
+    myUpload(file) {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve('\/\/deepexi.oss-cn-shenzhen.aliyuncs.com/deepexi-services/logo_Deepexi_640x640.jpg')
+        }, 2000)
+      })
+    },
+    uploadStart(){
+      console.log('start')
+    },
+    uploadEnd(status, res){
+      console.log('end', status, res)
+    }
+  }
+}
+</script>
+```
+
+设置upload-to-ali的大小限制，兼容overSize等事件
+
+```vue
+<template>
+  <v-editor ref="e" v-model="content" :upload-options="uploadOptions"  @upload-start="uploadStart" @upload-end="uploadEnd"  />
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      content: '',
+      uploadOptions: {
+        request: this.myUpload,
+        size: 100,
+        onOversize: () => this.$message.warning('请选择100K以内的图片')
       }
     }
   },

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -20,14 +20,15 @@
 
 <script>
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor'
-import UploadToAli from '@femessage/upload-to-ali'
+// import UploadToAli from '@femessage/upload-to-ali'
+import UploadToAli from '../../upload-to-ali/src'
+
 import defaultEditorOptions from './defaultEditorOptions'
 import debounce from 'lodash-es/debounce'
 import merge from 'lodash-es/merge'
 import ImageUploader from './plugin/ImageUploader'
 import CKEditor from '@ckeditor/ckeditor5-vue'
 
-const oneKB = 1024
 export default {
   name: 'VEditor',
   components: {
@@ -133,26 +134,19 @@ export default {
     },
     uploadFile(file) {
       const uploadToAli = this.$refs.uploadToAli
-      const request = (async () => {
-        // 执行uploadToAli的beforeUpload
-        try {
-          await uploadToAli.beforeUpload([file])
-        } catch (e) {
-          throw new Error(e)
-        }
-        // 检查有无oversize的文件
-        const isOverSize = file.size > uploadToAli.size * oneKB
-        if (isOverSize) {
-          uploadToAli.onOversize(isOverSize)
-          throw new Error(isOverSize)
-        }
-
-        return uploadToAli.uploadRequest(file)
-      })()
+      // 模拟upload-to-ali 的upload传参
+      const request = uploadToAli.upload({
+        target: {files: [file]}
+      })
       this.$emit('upload-start')
       request
         .then(res => {
-          this.$emit('upload-end', true, res)
+          // res没有返回意味着上传失败
+          if (res) {
+            this.$emit('upload-end', true, res)
+          } else {
+            this.$emit('upload-end', false, 'fail')
+          }
         })
         .catch(e => {
           this.$emit('upload-end', false, e)

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -20,8 +20,7 @@
 
 <script>
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor'
-// import UploadToAli from '@femessage/upload-to-ali'
-import UploadToAli from '../../upload-to-ali/src'
+import UploadToAli from '@femessage/upload-to-ali'
 
 import defaultEditorOptions from './defaultEditorOptions'
 import debounce from 'lodash-es/debounce'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,9 +1185,9 @@
   integrity sha1-Cp5qyZ4X+Zw7QBJ5Hx90IILetZE=
 
 "@femessage/upload-to-ali@^2.1.2":
-  version "2.1.6"
-  resolved "https://registry.npm.taobao.org/@femessage/upload-to-ali/download/@femessage/upload-to-ali-2.1.6.tgz#ade8be53ff817fb7dd8efe5d7a4bc892e1ee200c"
-  integrity sha1-rei+U/+Bf7fdjv5dekvIkuHuIAw=
+  version "2.1.7"
+  resolved "https://registry.npm.taobao.org/@femessage/upload-to-ali/download/@femessage/upload-to-ali-2.1.7.tgz#edf24e76b4c7654165e613a1afdc0773e73896e2"
+  integrity sha1-7fJOdrTHZUFl5hOhr9wHc+c4luI=
   dependencies:
     "@femessage/img-preview" "^1.2.0"
     compressorjs "^1.0.6"
@@ -3488,7 +3488,7 @@ compression@^1.7.4:
 
 compressorjs@^1.0.6:
   version "1.0.6"
-  resolved "https://registry.npm.taobao.org/compressorjs/download/compressorjs-1.0.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcompressorjs%2Fdownload%2Fcompressorjs-1.0.6.tgz#75c55e2c3d797afeaa3084bd0cbf03e8374e4b6d"
+  resolved "https://registry.npm.taobao.org/compressorjs/download/compressorjs-1.0.6.tgz#75c55e2c3d797afeaa3084bd0cbf03e8374e4b6d"
   integrity sha1-dcVeLD15ev6qMIS9DL8D6DdOS20=
   dependencies:
     blueimp-canvas-to-blob "^3.16.0"
@@ -4651,9 +4651,9 @@ element-ui@^2.7.2:
     throttle-debounce "^1.0.1"
 
 elliptic@^6.0.0, elliptic@^6.5.2:
-  version "6.5.2"
-  resolved "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=
+  version "6.5.3"
+  resolved "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.3.tgz?cache=0&sync_timestamp=1592492805287&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Felliptic%2Fdownload%2Felliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -10058,9 +10058,9 @@ path-type@^4.0.0:
   integrity sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=
 
 pbkdf2@^3.0.3:
-  version "3.0.17"
-  resolved "https://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
-  integrity sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=
+  version "3.1.1"
+  resolved "https://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
+  integrity sha1-y4cksPramEWWhW0abrr9NYRlS5Q=
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,7 +4204,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npm.taobao.org/debuglog/download/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -6492,7 +6492,7 @@ import-local@2.0.0, import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npm.taobao.org/imurmurhash/download/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -8284,11 +8284,6 @@ lodash-es@^4.17.10, lodash-es@^4.17.15:
   resolved "https://registry.npm.taobao.org/lodash-es/download/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha1-Ib2Wg5NUQS8j16EDQOXqxu5FXXg=
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.npm.taobao.org/lodash._baseindexof/download/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npm.taobao.org/lodash._baseuniq/download/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -8297,32 +8292,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.npm.taobao.org/lodash._bindcallback/download/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.npm.taobao.org/lodash._cacheindexof/download/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.npm.taobao.org/lodash._createcache/download/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.npm.taobao.org/lodash._createset/download/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.npm.taobao.org/lodash._getnative/download/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -8348,11 +8321,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npm.taobao.org/lodash.memoize/download/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.npm.taobao.org/lodash.restparam/download/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
fix #104 
## How
1. 和 `upload-to-ali`对比后，`v-editor` 是直接执行 `upload-to-ali` 的 `uploadRequest` 方法，而 `upload-to-ali` 执行`uploadRequest`时有大量的前置操作，这就导致`v-editor` 里设置 某些`upload-to-ali` 不生效的原因

![image](https://user-images.githubusercontent.com/19562649/86429541-7bb1a980-bd22-11ea-9fc6-fa75617b2187.png)
![image](https://user-images.githubusercontent.com/19562649/86429635-bc112780-bd22-11ea-898b-efed11d60569.png)

2. 直接调用  `upload-to-ali`的upload方法，参数构造成其对应的传参
```javascript
   const request = uploadToAli.upload({
        target: {files: [file]}
      })
```

3.该方式需要等待 `upload-to-ali` 的更新
