### PR TITLE
fix: 附件上传按钮无法禁用

### DIFF
--- a/src/plugin/AttachmentUpload.js
+++ b/src/plugin/AttachmentUpload.js
@@ -22,11 +22,15 @@ export default class AttachmentUpload extends Plugin {
       // 文件选择器类型按钮
       const view = new FileDialogButtonView(locale)
 
+      const command = editor.commands.get('attachmentUpload')
+
       view.buttonView.set({
         label: '附件上传',
         icon: attachmentIcon,
         tooltip: true
       })
+
+      view.buttonView.bind('isEnabled').to(command)
 
       // 文件选择结束回调
       view.on('done', (_, file) => {


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
编辑禁用状态下，附件上传按钮依然可用

## How
Describe your steps:
1. 增加禁用钩子



## Preview
### before
![image](https://user-images.githubusercontent.com/27952659/91433208-80fc2200-e895-11ea-89f6-af62a580d19e.png)

### after
![image](https://user-images.githubusercontent.com/27952659/91433112-54e0a100-e895-11ea-8a15-1784251e9eb2.png)

