### PR TITLE
fix: 修复 \n 换行符未换行问题

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,3 @@
-export function replaceWrap(str, replaceStr) {
+export function replaceNewline(str, replaceStr) {
   return str.replace(/\r?\n/g, replaceStr)
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,3 @@
+export function replaceWrap(str, replaceStr) {
+  return str.replace(/\r?\n/g, replaceStr)
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,3 @@
-export function replaceNewline(str, replaceStr) {
-  return str.replace(/\r?\n/g, replaceStr)
+export function replaceNewlineWithBr(str) {
+  return str.replace(/\r?\n/g, '<br>')
 }

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -137,6 +137,7 @@ export default {
   },
   computed: {
     computedValue() {
+      // TODO: 此处每次监听 this.value 的变化可能存在性能问题
       return replaceNewlineWithBr(this.value)
     },
     editorConfig() {

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -44,7 +44,7 @@ import fullScreenExitIcon from './assets/fullscreenexit.vue'
 
 import ImagePreview from './plugin/ImagePreview'
 import './translations'
-import {replaceWrap} from './utils'
+import {replaceNewline} from './utils'
 
 const ROW_HEIGHT = 24
 const INNER_PADDING = 8 * 2 + 1 * 2 // .ck-content padding + border
@@ -137,7 +137,7 @@ export default {
   },
   computed: {
     computedValue() {
-      return replaceWrap(this.value, '<br>')
+      return replaceNewline(this.value, '<br>')
     },
     editorConfig() {
       // $refs 在 mounted 阶段才挂载，这里不能直接传实例

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -2,7 +2,7 @@
   <div class="v-editor">
     <ckeditor
       :editor="ClassicEditor"
-      :value="value"
+      :value="computedValue"
       :disabled="disabled"
       :config="editorConfig"
       @input="onInput"
@@ -44,6 +44,7 @@ import fullScreenExitIcon from './assets/fullscreenexit.vue'
 
 import ImagePreview from './plugin/ImagePreview'
 import './translations'
+import {replaceWrap} from './utils'
 
 const ROW_HEIGHT = 24
 const INNER_PADDING = 8 * 2 + 1 * 2 // .ck-content padding + border
@@ -135,6 +136,9 @@ export default {
     }
   },
   computed: {
+    computedValue() {
+      return replaceWrap(this.value, '<br>')
+    },
     editorConfig() {
       // $refs 在 mounted 阶段才挂载，这里不能直接传实例
       return Object.assign(

--- a/src/v-editor.vue
+++ b/src/v-editor.vue
@@ -44,7 +44,7 @@ import fullScreenExitIcon from './assets/fullscreenexit.vue'
 
 import ImagePreview from './plugin/ImagePreview'
 import './translations'
-import {replaceNewline} from './utils'
+import {replaceNewlineWithBr} from './utils'
 
 const ROW_HEIGHT = 24
 const INNER_PADDING = 8 * 2 + 1 * 2 // .ck-content padding + border
@@ -137,7 +137,7 @@ export default {
   },
   computed: {
     computedValue() {
-      return replaceNewline(this.value, '<br>')
+      return replaceNewlineWithBr(this.value)
     },
     editorConfig() {
       // $refs 在 mounted 阶段才挂载，这里不能直接传实例

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,10 @@
-import {replaceWrap} from '../src/utils'
+import {replaceNewline} from '../src/utils'
 
 test('replaceNewlineWithBr', () => {
   const replaceStr = '<br>'
   const strInWindows = '1.登录平台，选择需求池tab\r\n2.需求列表有需求'
   const strInUnix = '1.登录平台，选择需求池tab\n2.需求列表有需求'
   const normalStr = `1.登录平台，选择需求池tab${replaceStr}2.需求列表有需求`
-  expect(replaceWrap(strInWindows, replaceStr)).toBe(normalStr)
-  expect(replaceWrap(strInUnix, replaceStr)).toBe(normalStr)
+  expect(replaceNewline(strInWindows, replaceStr)).toBe(normalStr)
+  expect(replaceNewline(strInUnix, replaceStr)).toBe(normalStr)
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,10 @@
-import sum from './sum'
+import {replaceWrap} from '../src/utils'
 
-test('main', () => {
-  expect(sum(1, 2)).toBe(3)
+test('replaceNewlineWithBr', () => {
+  const replaceStr = '<br>'
+  const strInWindows = '1.登录平台，选择需求池tab\r\n2.需求列表有需求'
+  const strInUnix = '1.登录平台，选择需求池tab\n2.需求列表有需求'
+  const normalStr = `1.登录平台，选择需求池tab${replaceStr}2.需求列表有需求`
+  expect(replaceWrap(strInWindows, replaceStr)).toBe(normalStr)
+  expect(replaceWrap(strInUnix, replaceStr)).toBe(normalStr)
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,9 @@
-import {replaceNewline} from '../src/utils'
+import {replaceNewlineWithBr} from '../src/utils'
 
 test('replaceNewlineWithBr', () => {
-  const replaceStr = '<br>'
   const strInWindows = '1.登录平台，选择需求池tab\r\n2.需求列表有需求'
   const strInUnix = '1.登录平台，选择需求池tab\n2.需求列表有需求'
-  const normalStr = `1.登录平台，选择需求池tab${replaceStr}2.需求列表有需求`
-  expect(replaceNewline(strInWindows, replaceStr)).toBe(normalStr)
-  expect(replaceNewline(strInUnix, replaceStr)).toBe(normalStr)
+  const normalStr = `1.登录平台，选择需求池tab<br>2.需求列表有需求`
+  expect(replaceNewlineWithBr(strInWindows)).toBe(normalStr)
+  expect(replaceNewlineWithBr(strInUnix)).toBe(normalStr)
 })


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
[换行符消失 · Issue #118 · FEMessage/v-editor](https://github.com/FEMessage/v-editor/issues/118)

## How
替换 换行符为 `<br>`

## Test
```js
test('replaceNewlineWithBr', () => {
  const replaceStr = '<br>'
  const strInWindows = '1.登录平台，选择需求池tab\r\n2.需求列表有需求'
  const strInUnix = '1.登录平台，选择需求池tab\n2.需求列表有需求'
  const normalStr = `1.登录平台，选择需求池tab${replaceStr}2.需求列表有需求`
  expect(replaceWrap(strInWindows, replaceStr)).toBe(normalStr)
  expect(replaceWrap(strInUnix, replaceStr)).toBe(normalStr)
})

```

## Screenshot
![before](https://user-images.githubusercontent.com/27998490/92205175-b61cfb80-eeb7-11ea-927f-3ae405756303.png)
**before**

![after](https://user-images.githubusercontent.com/27998490/92205237-d2b93380-eeb7-11ea-969b-63fbb350abcf.png)
**after**